### PR TITLE
Update screenshot helpers for temp path

### DIFF
--- a/MacMCP/Tests/TestsWithoutMocks/ToolE2ETests/ScreenshotToolE2ETests.swift
+++ b/MacMCP/Tests/TestsWithoutMocks/ToolE2ETests/ScreenshotToolE2ETests.swift
@@ -513,7 +513,10 @@ struct ScreenshotToolE2ETests {
   private func saveScreenshotForInspection(
     imageData: Data, region: String, width: String, height: String
   ) {
-    let outputDir = "/Users/jesse/Documents/GitHub/projects/mac-mcp/MacMCP/test-screenshots"
+    // Use a temporary directory so the tests can run on any machine
+    let outputDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("macmcp-test-screenshots", isDirectory: true)
+      .path
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyyMMdd_HHmmss"
     let timestamp = dateFormatter.string(from: Date())
@@ -536,7 +539,10 @@ struct ScreenshotToolE2ETests {
 
   /// Save a screenshot with custom identifier for easier tracking
   private func saveScreenshotWithIdentifier(imageData: Data, identifier: String) {
-    let outputDir = "/Users/jesse/Documents/GitHub/projects/mac-mcp/MacMCP/test-screenshots"
+    // Use the temporary directory so the path is valid on any machine
+    let outputDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("macmcp-test-screenshots", isDirectory: true)
+      .path
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyyMMdd_HHmmss"
     let timestamp = dateFormatter.string(from: Date())

--- a/MacMCP/Tests/TestsWithoutMocks/ToolE2ETests/UIInteractionToolE2ETests.swift
+++ b/MacMCP/Tests/TestsWithoutMocks/ToolE2ETests/UIInteractionToolE2ETests.swift
@@ -1078,7 +1078,10 @@ struct UIInteractionToolE2ETests {
       if let content = result.first, case .image(let data, _, _) = content {
         let decodedData = Data(base64Encoded: data)!
 
-        let outputDir = "/Users/jesse/Documents/GitHub/projects/mac-mcp/MacMCP/test-screenshots"
+        // Save screenshots to a temporary directory so the path works on any machine
+        let outputDir = FileManager.default.temporaryDirectory
+          .appendingPathComponent("macmcp-test-screenshots", isDirectory: true)
+          .path
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyyMMdd_HHmmss"
         let timestamp = dateFormatter.string(from: Date())


### PR DESCRIPTION
## Summary
- update screenshot helper paths to use a temp directory so tests can run anywhere

## Testing
- `swift test --no-parallel` *(fails: Failed to clone repository)*